### PR TITLE
Allow passing a blank string as a FilePath

### DIFF
--- a/src/PyEnvironment.Local.pas
+++ b/src/PyEnvironment.Local.pas
@@ -130,22 +130,24 @@ procedure TPyLocalEnvironment.Prepare;
 var
   LFilePath: string;
 begin
-  LFilePath := TPyEnvironmentPath.ResolvePath(FFilePath);
-  if not TFile.Exists(LFilePath) then
-    raise Exception.Create('File not found.');
-
-  EnumerateEnvironments(
-    procedure(APythonVersion: string; AEnvironmentInfo: TJSONObject)
-    var
-      LDistribution: TPyLocalDistribution;
+  if not FFilePath.IsEmpty then
     begin
-      LDistribution := TPyLocalDistribution(Distributions.Add());
-      LDistribution.PythonVersion := APythonVersion;
-      LDistribution.Home := AEnvironmentInfo.GetValue<string>('home');
-      LDistribution.SharedLibrary := AEnvironmentInfo.GetValue<string>('shared_library');
-      LDistribution.Executable := AEnvironmentInfo.GetValue<string>('executable');
-    end);
+	  LFilePath := TPyEnvironmentPath.ResolvePath(FFilePath);
+	  if not TFile.Exists(LFilePath) then
+		raise Exception.Create('File not found.');
 
+	  EnumerateEnvironments(
+		procedure(APythonVersion: string; AEnvironmentInfo: TJSONObject)
+		var
+		  LDistribution: TPyLocalDistribution;
+		begin
+		  LDistribution := TPyLocalDistribution(Distributions.Add());
+		  LDistribution.PythonVersion := APythonVersion;
+		  LDistribution.Home := AEnvironmentInfo.GetValue<string>('home');
+		  LDistribution.SharedLibrary := AEnvironmentInfo.GetValue<string>('shared_library');
+		  LDistribution.Executable := AEnvironmentInfo.GetValue<string>('executable');
+		end);
+	end;
   inherited;
 end;
 


### PR DESCRIPTION
This extremely minor modification makes LocalPython far easier to use.

If a TPyLocalDistribution is added to the Distributions and a blank FilePath is passed then calling Setup will result in the recently added TPyLocalDistribution being used (providing it matches the PythonVersion of course).

I did think of checking if Distributions was empty to trigger this functionality but there exists the possibility that you want to add a new Distribution by FilePath so checking for blank FilePath covers more use cases.

I've tested this and, somewhat to my amazement, it worked first time.

Prior to this change I was having to write out a JSON file just so I could pass it into LocalPython as a parameter (not elegant at all)

![image](https://user-images.githubusercontent.com/1549219/189478839-7e281e44-5e0d-4413-84ad-5c18753ae984.png)

Cool, Eh?

PyScripter's PythonVersions is highly Windows-centric (there are a few bits of portable code) with his function GetRegisteredPythonVersion being highly desirable for FMX but not usable (Windows Only). I adapted what he was doing and produced a basic Mac version of the same thing (Linux later...) - currently mine is a little rudimentary and needs testing against more Distributions but it does work with the official distribution (tested with 3.9.12)
 