### PR TITLE
remove p4denvironmentproject from P4DEnvironment.dpk

### DIFF
--- a/packages/P4DEnvironment.dpk
+++ b/packages/P4DEnvironment.dpk
@@ -31,8 +31,7 @@ package P4DEnvironment;
 requires
   rtl,
   python,
-  p4dtools,
-  p4denvironmentproject;
+  p4dtools;
 
 contains
   PyEnvironment in '..\src\PyEnvironment.pas',


### PR DESCRIPTION
I was worried removing that require might break something but it all looks good

The require prevents e.g. Win64 from Building - dunno why Win32 passes...